### PR TITLE
Adding #alive? to ShellFuture, Sinks, Sources, and checking for it in datamover

### DIFF
--- a/lib/workers/data_mover.rb
+++ b/lib/workers/data_mover.rb
@@ -14,6 +14,10 @@ module Transferatu
   #                  #wait returns. Should return true iff the
   #                  Source drained all its data to the source
   #                  stream.
+  # #alive?        - Check if process is still running, by checking
+  #                  if the monitor thread is still running.
+  #                  Note: this thread is a just a c function which
+  #                  calls wait(2).
   # #cancel        - Cancel producing data (but do not close the
   #                  source). Note that #wait will still be called
   #                  after #cancel, and should return as promptly
@@ -30,6 +34,10 @@ module Transferatu
   #                  called after the input stream is closed. Should
   #                  return true iff the Sink read and processed all
   #                  data from the stream.
+  # #alive?        - Check if process is still running, by checking
+  #                  if the monitor thread is still running.
+  #                  Note: this thread is a just a c function which
+  #                  calls wait(2).
   # #cancel        - Cancel consuming data (but do not close the
   #                  Sink). Note that #wait will still be called
   #                  after #cancel. If #cancel is called, #wait must
@@ -70,7 +78,7 @@ module Transferatu
         sink_stream = @sink.run_async
 
         begin
-          until source_stream.eof?
+          until source_stream.eof? || !@source.alive? || !@sink.alive?
             copied = IO.copy_stream(source_stream, sink_stream, CHUNK_SIZE)
             @lock.synchronize { @processed_bytes += copied }
           end

--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -94,7 +94,7 @@ module Transferatu
     # If the thread is running, process.wait has not returned,
     # and the process is alive
     def alive?
-      @wthr.value
+      @wthr.alive?
     end
 
     # Wait for the process to finish. Returns the resulting

--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -91,6 +91,12 @@ module Transferatu
       drain_stream(@stderr, logger)
     end
 
+    # If the thread is running, process.wait has not returned,
+    # and the process is alive
+    def alive?
+      @wthr.value
+    end
+
     # Wait for the process to finish. Returns the resulting
     # Process::Status of the process.
     def wait
@@ -188,6 +194,10 @@ module Transferatu
       @logger.call "pg_dump done"
       result.success? == true
     end
+
+    def alive?
+      @future.alive?
+    end
   end
 
   # A Sink that uploads to S3
@@ -223,6 +233,10 @@ module Transferatu
       result = @future.wait
       @logger.call "upload done"
       result.success? == true
+    end
+
+    def alive?
+      @future.alive?
     end
   end
 
@@ -295,6 +309,10 @@ module Transferatu
         return false
       end
     end
+
+    def alive?
+      @future.alive?
+    end
   end
 
   # A source that runs Gof3r to fetch from an S3 URL
@@ -329,6 +347,10 @@ module Transferatu
       result = @future.wait
       @logger.call "download done"
       result.success? == true
+    end
+
+    def alive?
+      @future.alive?
     end
   end
 end

--- a/spec/workers/data_mover_spec.rb
+++ b/spec/workers/data_mover_spec.rb
@@ -13,6 +13,9 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(short_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
+
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
 
@@ -25,6 +28,9 @@ module Transferatu
     it "should run transfers larger than chunk size" do
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
+
+      expect(source).to receive(:alive?).twice.and_return(true)
+      expect(sink).to receive(:alive?).twice.and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
@@ -43,6 +49,9 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
+
       expect(sink_stream).to receive(:write).and_raise(Errno::EPIPE)
 
       expect(source).to receive(:wait).and_return(true)
@@ -56,6 +65,9 @@ module Transferatu
       err = StandardError.new("oh snap")
       expect(sink).to receive(:run_async).and_return(sink_stream)
       expect(IO).to receive(:copy_stream).and_raise(err)
+
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)


### PR DESCRIPTION
> one of the tricky parts is that with open3, i didn't really find a good way to check if the process is alive without actually waiting for it to complete

open3 returns a wait thread, the same wait thread that is returned by Process.detach. The wait thread is just a c-builtin, spinning on waitpid, and like any other thread, it has an #alive? method.

I reckon we should be able to use wait_thread.alive? as a proxy for if the process is running.