### PR TITLE
Include all logs in serialized representation

### DIFF
--- a/lib/models/log.rb
+++ b/lib/models/log.rb
@@ -43,7 +43,7 @@ module Transferatu
       logs_dataset = Log.select(:level, :created_at, :message)
         .where(foreign_uuid: self.uuid)
         .order_by(Sequel.desc(:created_at))
-      if limit > 0
+      if limit && limit >= 0
         logs_dataset = logs_dataset.limit(limit)
       end
       logs_dataset.all

--- a/lib/serializers/transfer_serializer.rb
+++ b/lib/serializers/transfer_serializer.rb
@@ -6,7 +6,7 @@ module Transferatu::Serializers
 
     structure(:verbose) do |transfer|
       response = basic_structure(transfer)
-      response[:logs] = transfer.logs.reject do |item|
+      response[:logs] = transfer.logs(limit: nil).reject do |item|
         item.level == 'internal'
       end.sort_by(&:created_at).map do |item|
         {

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -75,6 +75,11 @@ describe Transferatu::Log do
         expect(loggable.logs(limit: -1).count)
           .to eq(Transferatu::Log.where(foreign_uuid: loggable.uuid).count)
       end
+
+      it "returns all logs with a nil limit" do
+        expect(loggable.logs(limit: nil).count)
+          .to eq(Transferatu::Log.where(foreign_uuid: loggable.uuid).count)
+      end
     end
   end
 end

--- a/spec/serializers/transfer_serializer_spec.rb
+++ b/spec/serializers/transfer_serializer_spec.rb
@@ -18,4 +18,33 @@ describe Transferatu::Serializers::Transfer do
     result = serializer.serialize(xfer)
     expect(result[:schedule]).to_not be_nil
   end
+
+  context "verbose representation" do
+    let(:serializer) { Transferatu::Serializers::Transfer.new(:verbose) }
+    let(:message)    { 'hello world' }
+
+    it "includes logs" do
+      xfer.log(message)
+      result = serializer.serialize(xfer)
+      expect(result[:logs].count).to eq(1)
+      log_item = result[:logs].first
+      expect(log_item[:created_at]).not_to be_nil
+      expect(log_item[:level]).to eq('info')
+      expect(log_item[:message]).to eq(message)
+    end
+
+    it "excludes internal log lines" do
+      xfer.log(message)
+      xfer.log("some internal note", level: :internal)
+      result = serializer.serialize(xfer)
+      expect(result[:logs].count).to eq(1)
+      expect(result[:logs].first[:message]).to eq(message)
+    end
+
+    it "includes all logs" do
+      201.times { xfer.log(message) }
+      result = serializer.serialize(xfer)
+      expect(result[:logs].count).to eq(201)
+    end
+  end
 end


### PR DESCRIPTION
Currently we arbitrarily cut them off at 200. This can be useful for console investigations, but doesn't make sense to limit like this when showing logs to the user.