### PR TITLE
Print exit process status

### DIFF
--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -223,7 +223,7 @@ module Transferatu
     def wait
       @logger.call "waiting for upload to complete"
       result = @future.wait
-      @logger.call "upload done"
+      @logger.call "upload done: #{result.inspect}"
       result.success? == true
     end
   end


### PR DESCRIPTION
To figure out what is causing an otherwise successful-looking
upload (per the logs) from recording as such in the database.

As-is only "upload done" will be printed, being indistinguishable
between successful and unsuccessful cases.  Now it will be suffixed with
process status output like the following:

    #<Process::Status: pid 17667 exit 3>
    #<Process::Status: pid 17671 SIGTERM (signal 15)>