### PR TITLE
Always start non-scheduled transfers first

### DIFF
--- a/lib/models/transfer.rb
+++ b/lib/models/transfer.rb
@@ -22,7 +22,8 @@ module Transferatu
       self.db.transaction(isolation: :serializable) do
         Transfer.with_sql(<<-EOF).first
 WITH oldest_pending AS (
-  SELECT uuid FROM transfers WHERE started_at IS NULL ORDER BY created_at LIMIT 1
+  SELECT uuid FROM transfers WHERE started_at IS NULL
+  ORDER BY schedule_id IS NULL DESC, created_at LIMIT 1
 )
 UPDATE
   transfers SET started_at = now()

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -23,6 +23,12 @@ module Transferatu
         t1.update(started_at: Time.now)
         expect(Transfer.begin_next_pending).to be_nil
       end
+      it "prioritizes non-scheduled transfers" do
+        create(:transfer,
+               created_at: t0.created_at - 10.minutes,
+               schedule: create(:schedule))
+        expect(Transfer.begin_next_pending.uuid).to eq(t0.uuid)
+      end
     end
 
     describe ".in_progress" do


### PR DESCRIPTION
Scheduled ones can wait.