### PR TITLE
Remove wait alt

### DIFF
--- a/lib/workers/data_mover.rb
+++ b/lib/workers/data_mover.rb
@@ -14,6 +14,10 @@ module Transferatu
   #                  #wait returns. Should return true iff the
   #                  Source drained all its data to the source
   #                  stream.
+  # #alive?        - Check if process is still running, by checking
+  #                  if the monitor thread is still running.
+  #                  Note: this thread is a just a c function which
+  #                  calls wait(2).
   # #cancel        - Cancel producing data (but do not close the
   #                  source). Note that #wait will still be called
   #                  after #cancel, and should return as promptly
@@ -30,6 +34,10 @@ module Transferatu
   #                  called after the input stream is closed. Should
   #                  return true iff the Sink read and processed all
   #                  data from the stream.
+  # #alive?        - Check if process is still running, by checking
+  #                  if the monitor thread is still running.
+  #                  Note: this thread is a just a c function which
+  #                  calls wait(2).
   # #cancel        - Cancel consuming data (but do not close the
   #                  Sink). Note that #wait will still be called
   #                  after #cancel. If #cancel is called, #wait must
@@ -70,7 +78,7 @@ module Transferatu
         sink_stream = @sink.run_async
 
         begin
-          until source_stream.eof?
+          until source_stream.eof? || !@source.alive? || !@sink.alive?
             copied = IO.copy_stream(source_stream, sink_stream, CHUNK_SIZE)
             @lock.synchronize { @processed_bytes += copied }
           end

--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -200,7 +200,7 @@ module Transferatu
     end
 
     def alive?
-      @future.alive?
+      @future && @future.alive?
     end
   end
 

--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -191,12 +191,14 @@ module Transferatu
     end
 
     def wait
+      return @succeeded unless @succeeded.nil?
+
       @logger.call "waiting for pg_dump to complete"
       result = @future.wait
       @logger.call "pg_dump done"
       @logger.call("exit status details: #{result.inspect}", level: :internal)
 
-      result.success? == true
+      @succeeded = result.success? == true
     end
 
     def alive?
@@ -233,12 +235,14 @@ module Transferatu
     end
 
     def wait
+      return @succeeded unless @succeeded.nil?
+
       @logger.call "waiting for upload to complete"
       result = @future.wait
       @logger.call "upload done"
       @logger.call("exit status details: #{result.inspect}", level: :internal)
 
-      result.success? == true
+      @succeeded = result.success? == true
     end
 
     def alive?
@@ -300,20 +304,22 @@ module Transferatu
     end
 
     def wait
+      return @succeeded unless @succeeded.nil?
+
       @logger.call "waiting for restore to complete"
       result = @future.wait
       @logger.call "restore done"
-      return true if result.success? == true
+      @succeeded = result.success? == true
 
       if result.exitstatus == 1
         expected_err_count = @failed_extension_comment_count
         if @failed_plpgsql_create
           expected_err_count += 1
         end
-        return expected_err_count == @pg_restore_error_count
-      else
-        return false
+        @succeeded = expected_err_count == @pg_restore_error_count
       end
+
+      return @succeeded
     end
 
     def alive?
@@ -349,10 +355,12 @@ module Transferatu
     end
 
     def wait
+      return @succeeded unless @succeeded.nil?
+
       @logger.call "waiting for download to complete"
       result = @future.wait
       @logger.call "download done"
-      result.success? == true
+      @succeeded = result.success? == true
     end
 
     def alive?
@@ -382,10 +390,12 @@ module Transferatu
     end
 
     def wait
+      return @succeeded unless @succeeded.nil?
+
       @logger.call "waiting for download to complete"
-      result = @future.wait
+      @result = @future.wait
       @logger.call "download done"
-      result.success? == true
+      @succeeded = @result.success? == true
     end
   end
 end

--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -93,6 +93,12 @@ module Transferatu
       drain_stream(@stderr, logger)
     end
 
+    # If the thread is running, process.wait has not returned,
+    # and the process is alive
+    def alive?
+      @wthr.alive?
+    end
+
     # Wait for the process to finish. Returns the resulting
     # Process::Status of the process.
     def wait
@@ -192,6 +198,10 @@ module Transferatu
 
       result.success? == true
     end
+
+    def alive?
+      @future.alive?
+    end
   end
 
   # A Sink that uploads to S3
@@ -229,6 +239,10 @@ module Transferatu
       @logger.call("exit status details: #{result.inspect}", level: :internal)
 
       result.success? == true
+    end
+
+    def alive?
+      @future.alive?
     end
   end
 
@@ -301,6 +315,10 @@ module Transferatu
         return false
       end
     end
+
+    def alive?
+      @future.alive?
+    end
   end
 
   # A source that runs Gof3r to fetch from an S3 URL we have access to
@@ -335,6 +353,10 @@ module Transferatu
       result = @future.wait
       @logger.call "download done"
       result.success? == true
+    end
+
+    def alive?
+      @future.alive?
     end
   end
 

--- a/lib/workers/transfer_worker.rb
+++ b/lib/workers/transfer_worker.rb
@@ -59,20 +59,17 @@ module Transferatu
       end
 
       begin
-        result = runner.run_transfer
-        if result
-          transfer.complete
-        else
-          transfer.fail
+        Rollbar.scoped(transfer_id: xfer_id) do
+          result = runner.run_transfer
+          if result
+            transfer.complete
+          else
+            transfer.fail
+          end
         end
       rescue Transfer::AlreadyFailed
         # ignore; if the transfer was canceled or otherwise failed
         # out of band, there's not much for us to do
-      rescue StandardError => e
-        transfer.log("Transfer failed for unexpected reason: #{e.message}\n #{e.backtrace.join("\n")}
-", level: :internal)
-        transfer.fail unless transfer.failed?
-        raise
       end
 
       progress_thr.join

--- a/spec/workers/data_mover_spec.rb
+++ b/spec/workers/data_mover_spec.rb
@@ -13,8 +13,8 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(short_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
-      expect(source).to receive(:alive?).and_return(true)
-      expect(sink).to receive(:alive?).and_return(true)
+      allow(source).to receive(:alive?).and_return(true)
+      allow(sink).to receive(:alive?).and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
@@ -29,8 +29,8 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
-      expect(source).to receive(:alive?).twice.and_return(true)
-      expect(sink).to receive(:alive?).twice.and_return(true)
+      allow(source).to receive(:alive?).and_return(true)
+      allow(sink).to receive(:alive?).and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
@@ -41,16 +41,31 @@ module Transferatu
       expect(sink_stream.length).to eq(long_source.length)
     end
 
-    it "should stop the transfer if the source fails" do
-      
+    it "should stop the transfer if reading from source raises" do
+      expect(source).to receive(:run_async).and_return(long_source)
+      expect(sink).to receive(:run_async).and_return(sink_stream)
+
+      allow(source).to receive(:alive?).and_return(true)
+      allow(sink).to receive(:alive?).and_return(true)
+
+      err = StandardError.new("oh snap")
+      expect(long_source).to receive(:read).and_raise(err)
+      expect(source).to receive(:cancel)
+      expect(sink).to receive(:cancel)
+      expect(Rollbar).to receive(:error).with(err)
+
+      expect(source).to receive(:wait).and_return(false)
+      expect(sink).to receive(:wait).and_return(false)
+
+      expect(mover.run_transfer).to be false
     end
 
     it "should stop the transfer if the sink fails" do
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
-      expect(source).to receive(:alive?).and_return(true)
-      expect(sink).to receive(:alive?).and_return(true)
+      allow(source).to receive(:alive?).and_return(true)
+      allow(sink).to receive(:alive?).and_return(true)
 
       expect(sink_stream).to receive(:write).and_raise(Errno::EPIPE)
 
@@ -60,42 +75,55 @@ module Transferatu
       expect(mover.run_transfer).to be false
     end
 
-    it "should stop the transfer and raise if copying data fails" do
+    it "should stop the transfer and report to Rollbar if copying data fails" do
       expect(source).to receive(:run_async).and_return(long_source)
       err = StandardError.new("oh snap")
       expect(sink).to receive(:run_async).and_return(sink_stream)
       expect(IO).to receive(:copy_stream).and_raise(err)
+      expect(Rollbar).to receive(:error).with(err)
 
-      expect(source).to receive(:alive?).and_return(true)
-      expect(sink).to receive(:alive?).and_return(true)
+      allow(source).to receive(:alive?).and_return(true, true, false)
+      allow(sink).to receive(:alive?).and_return(true, true, false)
 
-      expect(source).to receive(:wait).and_return(true)
-      expect(sink).to receive(:wait).and_return(true)
+      expect(source).to receive(:cancel)
+      expect(sink).to receive(:cancel)
 
-      expect { mover.run_transfer }.to raise_error(err)
+      expect(source).to receive(:wait).and_return(false)
+      expect(sink).to receive(:wait).and_return(false)
+
+      expect(mover.run_transfer).to be false
     end
 
-    it "should raise if source fails to run" do
+    it "should report to Rollbar if source fails to run" do
       err = StandardError.new("oh snap")
       expect(source).to receive(:run_async).and_raise(err)
+      expect(Rollbar).to receive(:error).with(err)
+
+      allow(source).to receive(:alive?).and_return(false)
+      allow(sink).to receive(:alive?).and_return(false)
 
       expect(source).not_to receive(:wait)
       expect(sink).not_to receive(:wait)
 
-      expect { mover.run_transfer }.to raise_error(err)
+      expect(mover.run_transfer).to be false
     end
 
-    it "should clean up source and raise if sink fails to run" do
+    it "should clean up source and report to Rollbar if sink fails to run" do
       expect(source).to receive(:run_async).and_return(long_source)
       err = StandardError.new("oh snap")
       expect(sink).to receive(:run_async).and_raise(err)
+      expect(Rollbar).to receive(:error).with(err)
 
-      expect(source).to receive(:wait).and_return(true)
+      allow(source).to receive(:alive?).and_return(true)
+      allow(sink).to receive(:alive?).and_return(false)
+
+      expect(source).to receive(:cancel).twice
+      expect(source).to receive(:wait).and_return(false)
       expect(sink).not_to receive(:wait)
 
-      expect { mover.run_transfer }.to raise_error(err)
+      expect(mover.run_transfer).to be false
     end
-    
+
     it "should cancel the source and sink when cancelled externally" do
       expect(source).to receive(:cancel)
       expect(sink).to receive(:cancel)

--- a/spec/workers/data_mover_spec.rb
+++ b/spec/workers/data_mover_spec.rb
@@ -13,6 +13,9 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(short_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
+
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
 
@@ -25,6 +28,9 @@ module Transferatu
     it "should run transfers larger than chunk size" do
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
+
+      expect(source).to receive(:alive?).twice.and_return(true)
+      expect(sink).to receive(:alive?).twice.and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)
@@ -43,6 +49,9 @@ module Transferatu
       expect(source).to receive(:run_async).and_return(long_source)
       expect(sink).to receive(:run_async).and_return(sink_stream)
 
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
+
       expect(sink_stream).to receive(:write).and_raise(Errno::EPIPE)
 
       expect(source).to receive(:wait).and_return(true)
@@ -56,6 +65,9 @@ module Transferatu
       err = StandardError.new("oh snap")
       expect(sink).to receive(:run_async).and_return(sink_stream)
       expect(IO).to receive(:copy_stream).and_raise(err)
+
+      expect(source).to receive(:alive?).and_return(true)
+      expect(sink).to receive(:alive?).and_return(true)
 
       expect(source).to receive(:wait).and_return(true)
       expect(sink).to receive(:wait).and_return(true)


### PR DESCRIPTION
This expands on #13 

There's no discussion on the PR, but if memory servers, we didn't merge it because it didn't handle the case where we still wait after the loop exits when the source is still running but the sink fails. I don't recall the exact mechanism, but the current code makes some assumptions about the relationship between the processes.

This attempts to make fewer assumptions: it exits the loop if either process dies (as in #13), but then explicitly cancels the other process if the first process to exit failed. This should make sure that workers are not stuck working on dead transfers.

Specs fail now but I can clean up if this approach looks reasonable.