### PR TITLE
Don't expire backups yet

### DIFF
--- a/lib/workers/schedule_processor.rb
+++ b/lib/workers/schedule_processor.rb
@@ -31,8 +31,8 @@ module Transferatu
                to_name:   data["to_name"],
                options:   data["options"] || {})
         schedule.mark_executed
-        Transferatu::Mediators::Schedules::Expirer
-          .run(schedule: schedule, expire_at: Time.now)
+        # Transferatu::Mediators::Schedules::Expirer
+        #   .run(schedule: schedule, expire_at: Time.now)
 
         schedule.group.log "Created scheduled transfer for #{schedule.name}"
       end

--- a/spec/workers/schedule_processor_spec.rb
+++ b/spec/workers/schedule_processor_spec.rb
@@ -34,7 +34,7 @@ module Transferatu
           processor.process(schedule)
         end
 
-        it "runs the expirer" do
+        xit "runs the expirer" do
           before = Time.now
           expect(Transferatu::Mediators::Schedules::Expirer).to receive(:run) do |opts|
             expect(opts[:schedule]).to be schedule


### PR DESCRIPTION
We mark as deleted after a week, not in line with limits in documentation.