### PR TITLE
Complete with warnings.

### DIFF
--- a/db/migrate/1437050371_add_warnings_column.rb
+++ b/db/migrate/1437050371_add_warnings_column.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:transfers) do
+      add_column :warnings, :integer
+    end
+  end
+end

--- a/lib/serializers/transfer_serializer.rb
+++ b/lib/serializers/transfer_serializer.rb
@@ -36,6 +36,7 @@ module Transferatu::Serializers
         source_bytes:    transfer.source_bytes,
         processed_bytes: transfer.processed_bytes,
         succeeded:       transfer.succeeded,
+        warnings:        (transfer.warnings || 0),
 
         created_at:  transfer.created_at,
         started_at:  transfer.started_at,

--- a/lib/workers/data_mover.rb
+++ b/lib/workers/data_mover.rb
@@ -61,6 +61,10 @@ module Transferatu
       @lock.synchronize { @processed_bytes }
     end
 
+    def warnings  
+      @sink && @sink.warnings
+    end
+
     # Cancel a transfer
     def cancel
       @source.cancel

--- a/lib/workers/transfer_worker.rb
+++ b/lib/workers/transfer_worker.rb
@@ -66,6 +66,7 @@ module Transferatu
           else
             transfer.fail
           end
+          transfer.update(warnings: runner.warnings) if runner.warnings
         end
       rescue Transfer::AlreadyFailed
         # ignore; if the transfer was canceled or otherwise failed

--- a/spec/workers/runner_factory_spec.rb
+++ b/spec/workers/runner_factory_spec.rb
@@ -507,15 +507,17 @@ module Transferatu
           end
           sink.run_async
           expect(sink.wait).to be true
+          expect(sink.warnings).to be 0
         end
-        it "returns false when process fails with comment errors not matching warning count" do
+        it "returns true when process fails with comment errors not matching warning count" do
           expect(future).to receive(:wait).and_return(failure)
           expect(future).to receive(:drain_stderr) do |l|
             l.call "Command was: COMMENT ON EXTENSION plpgsql IS 'hello'"
             l.call "WARNING: errors ignored on restore: 3"
           end
           sink.run_async
-          expect(sink.wait).to be false
+          expect(sink.wait).to be true
+          expect(sink.warnings).to be 3
         end
         it "returns true when process fails with PL/pgSQL failure matching warning count" do
           expect(future).to receive(:wait).and_return(failure)
@@ -525,6 +527,7 @@ module Transferatu
           end
           sink.run_async
           expect(sink.wait).to be true
+          expect(sink.warnings).to be 0
         end
         it "returns true when process fails with alternate PL/pgSQL failure matching warning count" do
           expect(future).to receive(:wait).and_return(failure)
@@ -534,6 +537,7 @@ module Transferatu
           end
           sink.run_async
           expect(sink.wait).to be true
+          expect(sink.warnings).to be 0
         end
         it "returns false when process fails with PL/pgSQL failure not matching warning count" do
           expect(future).to receive(:wait).and_return(failure)
@@ -542,7 +546,8 @@ module Transferatu
             l.call "WARNING: errors ignored on restore: 2"
           end
           sink.run_async
-          expect(sink.wait).to be false
+          expect(sink.wait).to be true
+          expect(sink.warnings).to be 2
         end
         it "returns true when the process fails with comment plus PL/pgSQL errors matching warning count" do
           expect(future).to receive(:wait).and_return(failure)
@@ -553,18 +558,19 @@ module Transferatu
           end
           sink.run_async
           expect(sink.wait).to be true
+          expect(sink.warnings).to be 0
         end
         it "returns false when the process fails otherwise" do
           expect(future).to receive(:wait).and_return(failure)
           sink.run_async
-          expect(sink.wait).to be true
+          expect(sink.wait).to be false
         end
         it "returns false when the process is signaled" do
           expect(future).to receive(:wait).and_return(signaled)
           sink.run_async
           expect(sink.wait).to be false
         end
-        it "returns false when process is signaled and has comment errors matching warning count" do
+        it "returns true when process is signaled and has comment errors matching warning count" do
           expect(future).to receive(:wait).and_return(signaled)
           expect(future).to receive(:drain_stderr) do |l|
             l.call "Command was: COMMENT ON EXTENSION plpgsql IS 'it is okay i guess'"
@@ -572,7 +578,8 @@ module Transferatu
             l.call "WARNING: errors ignored on restore: 2"
           end
           sink.run_async
-          expect(sink.wait).to be false
+          expect(sink.wait).to be true
+          expect(sink.warnings).to be 0
         end
       end
 

--- a/spec/workers/transfer_worker_spec.rb
+++ b/spec/workers/transfer_worker_spec.rb
@@ -21,6 +21,9 @@ module Transferatu
           sleep @dur
           @result
         end
+        def warnings
+          0
+        end
       end
 
       SLOW_RUNTIME = 0.1


### PR DESCRIPTION
Instead of using transfer.succeeded to determine if a transfer has failed or finished, use an additional warnings column to indiate a third state "Complete with warnings". A finished backup will have succeeded as true and warnings as 0. A complete with warnings has succeeded as true but warnings as non 0. Failure is still where succeeded is false.

Succeeded no longer depends on the exit code being 0, or the exit code being 1 and the error counts matching. Succeeded is when "restore done" is seen, and warnings are set if the exit code is non zero and the error counts do not match.