### PR TITLE
Use pg_dump --quote-all-identifiers option

### DIFF
--- a/lib/workers/runner_factory.rb
+++ b/lib/workers/runner_factory.rb
@@ -177,7 +177,8 @@ module Transferatu
       dbname = uri.path[1..-1]
       @env = { "LD_LIBRARY_PATH" => "#{root}/lib", "PGPASSWORD" => uri.password }
       @cmd = command("#{root}/bin/pg_dump",
-                     opts.merge(username: uri.user,
+                     opts.merge(quote_all_identifiers: true,
+                                username: uri.user,
                                 host: uri.host,
                                 port: uri.port || 5432), dbname)
       @logger = logger


### PR DESCRIPTION
In [5893ffa79c03824f34ae3d37f211381fd1c17283](https://github.com/postgres/postgres/commit/5893ffa79c03824f34ae3d37f211381fd1c17283), "over" was reclassified
as an unreserved keyword, which means it can now be used without
quotes as a table or column name (e.g., `CREATE TABLE over(over
int)`). However, when upgrading databases by piping a pg_dump into
a pg_restore, this can cause problems if upgrading a database from
before this change (which requires 'over' to be quoted when used as
a column name) to one with this change (where pg_dump does not think
that 'over' has to be quoted anymore).

We can't just use an old source database's pg_dump when upgrading,
because the newer target database may have introduced *other* reserved
keywords that the old pg_dump will not know to quote.

So we just quote the heck out of everything. The only downside is more
quotes in the text of the dump, which seems manageable.

/cc @mandagill