### PR TITLE
disable evictor

### DIFF
--- a/lib/workers/transfer_worker.rb
+++ b/lib/workers/transfer_worker.rb
@@ -85,8 +85,9 @@ module Transferatu
 
       progress_thr.join
 
-      Transferatu::Mediators::Transfers::Evictor
-        .run(transfer: transfer)
+      # TODO: fix this tomorrow
+      # This was disabled because eviction can evict manual backups
+      #Transferatu::Mediators::Transfers::Evictor.run(transfer: transfer)
     ensure
       @status.update(transfer: nil)
     end


### PR DESCRIPTION
as per https://support.heroku.com/tickets/343922?t=1458118079, this
evicts manual as well as scheduled backups. @tef told me to turn it off.