### PR TITLE
Make transferatu dogwood friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ $ heroku run bundle exec rake db:migrate
 $ heroku ps:scale clock=1 scheduler=1
 ```
 
+You'll have to create a user for Shogun to use when talking to Transferatu:
+```console
+$ heroku run bundle exec rake 'users:create[heroku-postgres-<your-name>]'
+```
+You'll then set the environment variables on your staging shogun.
+
 
 ## Quiescence
 

--- a/lib/models/worker_status.rb
+++ b/lib/models/worker_status.rb
@@ -15,7 +15,7 @@ module Transferatu
       if uuid.nil?
         # Dyno hostnames in private spaces have prefix "dyno-"
         self.uuid = Socket.gethostname
-        self.uuid.slice! "dyno-" if uuid.start_with? "dyno-"
+        self.uuid.slice!("dyno-") if uuid.start_with?("dyno-")
       end
       if host.nil?
         self.host = File.readlines('/etc/hosts').find do |line|

--- a/lib/models/worker_status.rb
+++ b/lib/models/worker_status.rb
@@ -13,7 +13,9 @@ module Transferatu
         self.dyno_name = ENV['DYNO']
       end
       if uuid.nil?
+        # Dyno hostnames in private spaces have prefix "dyno-"
         self.uuid = Socket.gethostname
+        self.uuid.slice! "dyno-" if uuid.start_with? "dyno-"
       end
       if host.nil?
         self.host = File.readlines('/etc/hosts').find do |line|


### PR DESCRIPTION
* Strip dyno prefix if found (Dogwood dyno hostnames are prefixed with `dyno-`)
* Update README to mention user creation