### PR TITLE
Ignore workers that are still provisioning

### DIFF
--- a/lib/workers/worker_manager.rb
+++ b/lib/workers/worker_manager.rb
@@ -12,7 +12,10 @@ module Transferatu
     def check_workers
       return if AppStatus.quiesced?
       existing_workers = running_workers
-      existing_statuses = WorkerStatus.check(*existing_workers.map { |w| w['name'] }).all
+
+      active_workers = existing_workers.select { |w| w['state'] == 'up' }
+      
+      existing_statuses = WorkerStatus.check(*active_workers.map { |w| w['name'] }).all
 
       # for each worker, make sure that it's "making progress"; ensure:
       #  - the worker was updated or created recently


### PR DESCRIPTION
On dogwood one-off dynos take much longer to come up and as such WorkerManager would frequently assume they'd failed and kill them before there were up and running.